### PR TITLE
Ensure card title is displayed even when the body is empty

### DIFF
--- a/crates/mdfmt-core/fixtures/format/card_with_title/input.md
+++ b/crates/mdfmt-core/fixtures/format/card_with_title/input.md
@@ -1,2 +1,7 @@
-> [!summary] foo
+> [!note] foo
+
+> [!note] foo
 > bar
+
+> [!summary] foo
+> # bar

--- a/crates/mdfmt-core/fixtures/format/card_with_title/output.md
+++ b/crates/mdfmt-core/fixtures/format/card_with_title/output.md
@@ -1,2 +1,7 @@
-> [!summary] foo
+> [!note] foo
+
+> [!note] foo
 > bar
+
+> [!summary] foo
+> # bar

--- a/crates/mdfmt-core/src/note/parser.rs
+++ b/crates/mdfmt-core/src/note/parser.rs
@@ -163,7 +163,7 @@ impl NoteParser {
         };
 
         if s.is_empty() && rest.is_empty() {
-            return Some((kind, None, None));
+            return Some((kind, title, None));
         };
 
         Some((


### PR DESCRIPTION
## Input
```
> [!note] foo
> bar

> [!summary] foo
> # bar
```

## Expected
```
> [!note] foo
> bar

> [!summary] foo
> # bar
```

## Actual
```
> [!note] foo
> bar

> [!summary]
> # bar
```